### PR TITLE
Fix characters for different default culture info

### DIFF
--- a/PLAWarper/PLAWarpWindow.cs
+++ b/PLAWarper/PLAWarpWindow.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using NHSE.Injection;
 
@@ -25,6 +22,7 @@ namespace PLADumper
         public PLAWarpWindow()
         {
             InitializeComponent();
+            CultureInfo.CurrentCulture = new CultureInfo("en-US", false);
         }
 
         private void Form1_Load(object sender, EventArgs e)


### PR DESCRIPTION
Sets the culture info to us-EN for the sake of coordinate decimals.